### PR TITLE
Use Edge product-level header

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -117,6 +117,8 @@
       "ms.topic": "reference",
       "ms.prod": "microsoft-edge",
       "ms.technology": "webview",
+      "searchScope": ["Microsoft Edge", "WebView2"],
+      "uhfHeaderId": "MSDocsHeader-MSEdge",
       "feedback_system": "None"
     },
     "fileMetadata": {},


### PR DESCRIPTION
Applied the same as in https://github.com/MicrosoftDocs/webview2-win32-reference/pull/40

> Hello, this content needs to use the Edge product-level header. Please let me know if you have any questions. If you're wondering "What is a product-level header?" please see:  https://review.docs.microsoft.com/en-us/help/onboard/admin/navigation-product-level-header?branch=main#what-is-product-level-navigation-for